### PR TITLE
Set up 1Password: desktop app, CLI, commit signing and secret rendering

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -165,6 +165,7 @@ NIXOS_OZONE_WL = "1";
 			hyprpicker
 			google-chrome
 			iio-hyprland
+			wvkbd
 			jq
       dbeaver-bin
       uv

--- a/configuration.nix
+++ b/configuration.nix
@@ -10,6 +10,7 @@
 			./stylix.nix
       ./azure-and-vpn.nix
       ./kubernetes-port-forwards.nix
+      ./onepassword.nix
     ];
 
 	

--- a/home.nix
+++ b/home.nix
@@ -15,6 +15,7 @@
     ./home/yazi.nix
     ./home/k9s.nix
     ./home/linear-notify.nix
+    ./home/onepassword-secrets.nix
   ];
   # Home Manager needs a bit of information about you and the paths it should
   # manage.

--- a/home/git.nix
+++ b/home/git.nix
@@ -21,9 +21,14 @@ in
         # SSH signatures rather than GPG, with 1Password holding the private
         # half. op-ssh-sign reaches the key through the desktop app's agent, so
         # nothing signable ever lands on disk.
+        #
+        # Deliberately the system path and not pkgs._1password-gui: the NixOS
+        # module installs the package with polkitPolicyOwners applied, and
+        # referring to the un-overridden one here would pull a second 583 MB
+        # copy of the app into the closure.
         signing = {
             format = "ssh";
-            signer = "${pkgs._1password-gui}/bin/op-ssh-sign";
+            signer = "/run/current-system/sw/bin/op-ssh-sign";
             key = signingKey;
             signByDefault = signingKey != null;
         };

--- a/home/git.nix
+++ b/home/git.nix
@@ -1,8 +1,33 @@
 { config, lib, pkgs, ...}:
+let
+    # Public half of the SSH key 1Password signs commits with, copied from the
+    # key's "public key" field in the vault. Signing stays off while this is
+    # null, because git rejects every commit once a signing format is set but
+    # the key is empty.
+    signingKey = null;
+in
 {
     programs.git = {
+        # Without this the whole module is inert and nothing here is written,
+        # which is how the signing settings below would silently do nothing.
+        # The generated file is ~/.config/git/config, which git reads alongside
+        # a hand-written ~/.gitconfig rather than replacing it, and loses to it
+        # on any key both of them set.
+        enable = true;
+
         userName = "leevisuo";
         userEmail = "leevi.suotula@gmail.com";
+
+        # SSH signatures rather than GPG, with 1Password holding the private
+        # half. op-ssh-sign reaches the key through the desktop app's agent, so
+        # nothing signable ever lands on disk.
+        signing = {
+            format = "ssh";
+            signer = "${pkgs._1password-gui}/bin/op-ssh-sign";
+            key = signingKey;
+            signByDefault = signingKey != null;
+        };
+
         aliases = {
             # Simple aliases
             ga = "add";

--- a/home/hypr/binds.nix
+++ b/home/hypr/binds.nix
@@ -12,6 +12,7 @@
 				"$mainMod, C, killactive"
 				"$mainMod, R, exec, rofi -show drun"
 				"$mainMod, G, exec, google-chrome-stable --ozone-platform=x11"
+				"$mainMod, I, exec, $HOME/.config/hypr/scripts/toggle-osk.sh"
 				"$mainMod, F, exec, $HOME/.config/hypr/scripts/focus_window_picker.sh"
 				"$mainMod, T, exec, $HOME/.config/hypr/scripts/focus_last_class.sh kitty"
 				"$mainMod, B, exec, $HOME/.config/hypr/scripts/focus_last_class.sh Google-chrome"

--- a/home/hypr/hyprland.nix
+++ b/home/hypr/hyprland.nix
@@ -18,6 +18,7 @@ in
 		./animation.nix
 		./waybar/waybar.nix
 		./inputs.nix
+		./touch.nix
 		./hypridle.nix
 		./hyprlock.nix
 
@@ -59,7 +60,8 @@ in
 			];
 			general = {
 				gaps_in = 3;
-				gaps_out = 5;
+				# top right bottom left — extra space at the screen bottom for touch reach
+				gaps_out = "5 5 50 5";
 				border_size = 2;
 				resize_on_border = true;
 				layout = "dwindle";

--- a/home/hypr/hyprland.nix
+++ b/home/hypr/hyprland.nix
@@ -53,6 +53,9 @@ in
 		settings = {
 			exec-once = [
 				"iio-hyprland"
+				# Started locked and hidden: the tray icon is enough to unlock, and
+				# the CLI and browser integrations both need the app already running.
+				"1password --silent &"
 				"sleep 1; waybar &"
 				"hyprlock &"
 				"wl-paste --type text --watch cliphist store &"

--- a/home/hypr/inputs.nix
+++ b/home/hypr/inputs.nix
@@ -4,6 +4,22 @@
             input = {
                 kb_layout = "us";
                 kb_variant = "altgr-intl";
+
+                touchpad = {
+                    natural_scroll = true;        # macOS-style: content follows fingers
+                    scroll_factor = 0.4;          # tame the fast default scroll speed
+                    disable_while_typing = true;  # ignore palm/thumb while typing
+                    tap-to-click = true;          # tap = left click
+                    tap-and-drag = true;          # tap-hold-move to drag
+                    drag_lock = true;             # brief lift keeps the drag alive
+                    clickfinger_behavior = true;  # 2-finger tap = right, 3 = middle
+                };
+            };
+
+            # 3-finger horizontal swipe to move between workspaces
+            gestures = {
+                workspace_swipe = true;
+                workspace_swipe_fingers = 3;
             };
             device = [
             {

--- a/home/hypr/scripts/chrome.sh
+++ b/home/hypr/scripts/chrome.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Google Chrome in touch mode — bound to the right-edge touch gesture.
+#   --top-chrome-touch-ui : fat, finger-sized tabs/toolbar
+#   --touch-events        : websites detect a touchscreen (mobile/touch paths)
+#   --ozone-platform=x11  : keep XWayland; native Wayland ozone crashes the AMD
+#                           Phoenix3 iGPU (same reason as Slack in configuration.nix)
+exec google-chrome-stable --ozone-platform=x11 \
+    --top-chrome-touch-ui=enabled --touch-events=enabled "$@"

--- a/home/hypr/scripts/toggle-osk.sh
+++ b/home/hypr/scripts/toggle-osk.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# wvkbd on-screen keyboard control:  show | hide | toggle  (default: toggle)
+#
+# Height is taller in landscape than portrait per preference — a bigger keyboard
+# when the screen is horizontal. wvkbd auto-selects -L vs -H from the current
+# output orientation, so no orientation detection is needed here.
+LAND=400   # -L landscape / horizontal height (bigger)
+PORT=300   # -H portrait / vertical height
+
+action="${1:-toggle}"
+
+running() { pgrep -x wvkbd-mobintl >/dev/null; }
+start()   { wvkbd-mobintl -L "$LAND" -H "$PORT" & disown; }
+
+case "$action" in
+    show)   running || start ;;
+    hide)   running && pkill -x wvkbd-mobintl ;;
+    toggle) if running; then pkill -x wvkbd-mobintl; else start; fi ;;
+esac

--- a/home/hypr/touch.nix
+++ b/home/hypr/touch.nix
@@ -1,0 +1,48 @@
+{ pkgs, ... }:
+{
+  # On-screen keyboard control script (summoned by gesture, waybar button, or key)
+  xdg.configFile."hypr/scripts/toggle-osk.sh" = {
+    source = ./scripts/toggle-osk.sh;
+    executable = true;
+  };
+
+  # Chrome launcher that enables touch UI only in tablet mode w/o external keyboard
+  xdg.configFile."hypr/scripts/chrome.sh" = {
+    source = ./scripts/chrome.sh;
+    executable = true;
+  };
+
+  wayland.windowManager.hyprland = {
+    # hyprgrass: touchSCREEN gestures. (Hyprland's built-in gestures.workspace_swipe
+    # in inputs.nix is a touchPAD gesture — a separate device, so no conflict.)
+    # Version-matched to pkgs.hyprland since both come from nixpkgs 25.05.
+    plugins = [ pkgs.hyprlandPlugins.hyprgrass ];
+
+    settings = {
+      plugin.touch_gestures = {
+        # Higher = need to move further before a swipe registers. 4 is a calm default.
+        sensitivity = 4.0;
+        # 3-finger drag left/right moves between workspaces, like a touchpad.
+        workspace_swipe_fingers = 3;
+        # Disable hyprgrass's SINGLE-finger edge workspace-swipe (defaults to the
+        # bottom edge), which otherwise steals the bottom-edge-up keyboard gesture.
+        workspace_swipe_edge = "none";
+        long_press_delay = 400;
+      };
+
+      # hyprgrass gesture binds. Gesture names act like keys in a normal `bind`.
+      #   edge:<from>:<dir>  swipe starting at a screen edge, in a direction
+      #   swipe:<n>:<dir>    n-finger swipe (n must be >= 3; 2-finger is scroll)
+      bind = [
+        # 3-finger swipe UP -> show the on-screen keyboard, DOWN -> hide it.
+        # (3-finger left/right is the workspace swipe, configured above.)
+        ", swipe:3:u, exec, $HOME/.config/hypr/scripts/toggle-osk.sh show"
+        ", swipe:3:d, exec, $HOME/.config/hypr/scripts/toggle-osk.sh hide"
+        # Edge swipes (single finger, from a screen edge inward/down):
+        ", edge:l:r, exec, rofi -show drun"                    # left edge  -> launcher
+        ", edge:r:l, exec, $HOME/.config/hypr/scripts/chrome.sh" # right edge -> Chrome
+        ", edge:u:d, killactive"                               # top edge   -> close window
+      ];
+    };
+  };
+}

--- a/home/hypr/waybar/waybar.nix
+++ b/home/hypr/waybar/waybar.nix
@@ -16,7 +16,13 @@
         # Fixed the typo here from "cloack" to "clock/calendar"
         modules-left = [ "battery" "network" "pulseaudio" "bluetooth" ];
         modules-center = [ "hyprland/workspaces" ];
-        modules-right = [ "custom/weather" "clock#calendar" "clock"  ];
+        modules-right = [ "custom/keyboard" "custom/weather" "clock#calendar" "clock"  ];
+
+        "custom/keyboard" = {
+          format = "󰌌";
+          tooltip = false;
+          on-click = "$HOME/.config/hypr/scripts/toggle-osk.sh";
+        };
 
         "clock" = {
           format = "{:%H:%M}";

--- a/home/linear-notify.nix
+++ b/home/linear-notify.nix
@@ -91,8 +91,10 @@ in
   systemd.user.services.linear-notify = {
     Unit = {
       Description = "Linear notification poller";
+      # Ordered after the render but deliberately not pulling it in: this unit
+      # runs from a 30s timer, and a Wants= would re-activate a failed render
+      # on every tick, asking 1Password to unlock each time.
       After = [ "graphical-session.target" "op-secrets.service" ];
-      Wants = [ "op-secrets.service" ];
       PartOf = [ "graphical-session.target" ];
     };
     Service = {

--- a/home/linear-notify.nix
+++ b/home/linear-notify.nix
@@ -91,14 +91,21 @@ in
   systemd.user.services.linear-notify = {
     Unit = {
       Description = "Linear notification poller";
-      After = [ "graphical-session.target" ];
+      After = [ "graphical-session.target" "op-secrets.service" ];
+      Wants = [ "op-secrets.service" ];
       PartOf = [ "graphical-session.target" ];
     };
     Service = {
       Type = "oneshot";
       ExecStart = "${script}";
-      # Create ~/.config/linear/credentials with: LINEAR_API_KEY=lin_api_xxxxx
-      EnvironmentFile = "%h/.config/linear/credentials";
+      # Both files are optional, and the later one wins: the API key normally
+      # comes from 1Password, but a hand-written ~/.config/linear/credentials
+      # holding LINEAR_API_KEY=lin_api_xxxxx still works. With neither present
+      # the poller sees an empty key and exits without notifying.
+      EnvironmentFile = [
+        "-%h/.config/linear/credentials"
+        "-%t/op-secrets/linear.env"
+      ];
     };
   };
 

--- a/home/onepassword-secrets.nix
+++ b/home/onepassword-secrets.nix
@@ -21,14 +21,30 @@ let
   # group, so the bare store binary would fail to resolve any reference.
   opSecrets = pkgs.writeShellApplication {
     name = "op-secrets";
+    runtimeInputs = [ pkgs.coreutils ];
     text = ''
       dir="''${XDG_RUNTIME_DIR:?XDG_RUNTIME_DIR is not set}/op-secrets"
       mkdir -p "$dir"
       chmod 700 "$dir"
       umask 077
-      ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: vars:
-        "/run/wrappers/bin/op inject --force --in-file ${templateFor name vars} --out-file \"$dir/${name}.env\""
-      ) cfg.envFiles)}
+
+      render() {
+        : # keeps the function valid when nothing is declared
+        ${lib.concatStringsSep "\n  " (lib.mapAttrsToList (name: vars:
+          "/run/wrappers/bin/op inject --force --in-file ${templateFor name vars} --out-file \"$dir/${name}.env\""
+        ) cfg.envFiles)}
+      }
+
+      # The desktop app is normally still starting when the session reaches
+      # this point, and op cannot resolve a reference before the app answers.
+      # Retry for a while rather than leaving the session without its secrets.
+      for attempt in 1 2 3 4 5; do
+        if render; then exit 0; fi
+        echo "op-secrets: render failed (attempt $attempt), retrying in 5s" >&2
+        sleep 5
+      done
+      echo "op-secrets: giving up — is 1Password running and unlocked?" >&2
+      exit 1
     '';
   };
 in
@@ -64,8 +80,8 @@ in
       };
       Service = {
         Type = "oneshot";
-        # Consumers pull this in via Wants=; without this they would re-trigger
-        # a render, and a fresh unlock prompt, on every activation.
+        # The rendered files outlive the process, so the unit should read as
+        # active once it has run rather than as dead.
         RemainAfterExit = true;
         ExecStart = lib.getExe opSecrets;
       };

--- a/home/onepassword-secrets.nix
+++ b/home/onepassword-secrets.nix
@@ -1,0 +1,75 @@
+# Secrets fetched from 1Password at login instead of living in hand-maintained
+# dotfiles.
+#
+# Each declared env file is rendered into $XDG_RUNTIME_DIR/op-secrets/<name>.env,
+# which is tmpfs-backed and private to the session, so no secret material is ever
+# written to disk or to the Nix store. The templates that drive the rendering
+# contain only `op://` references, never values, which is why they are safe to
+# keep in the world-readable store.
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.onepassword-secrets;
+
+  templateFor = name: vars:
+    pkgs.writeText "op-secrets-${name}.env" (
+      lib.concatStringsSep "\n" (lib.mapAttrsToList (var: ref: "${var}=${ref}") vars) + "\n"
+    );
+
+  # Invoked through the setgid wrapper rather than `pkgs._1password-cli`: the
+  # desktop app only answers a process it can attribute to the `onepassword-cli`
+  # group, so the bare store binary would fail to resolve any reference.
+  opSecrets = pkgs.writeShellApplication {
+    name = "op-secrets";
+    text = ''
+      dir="''${XDG_RUNTIME_DIR:?XDG_RUNTIME_DIR is not set}/op-secrets"
+      mkdir -p "$dir"
+      chmod 700 "$dir"
+      umask 077
+      ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: vars:
+        "/run/wrappers/bin/op inject --force --in-file ${templateFor name vars} --out-file \"$dir/${name}.env\""
+      ) cfg.envFiles)}
+    '';
+  };
+in
+{
+  options.services.onepassword-secrets.envFiles = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.attrsOf lib.types.str);
+    default = { };
+    example = lib.literalExpression ''
+      {
+        linear.LINEAR_API_KEY = "op://Private/Linear/credential";
+      }
+    '';
+    description = ''
+      Environment files to render from 1Password. Each attribute name becomes
+      `$XDG_RUNTIME_DIR/op-secrets/<name>.env` holding one `VAR=value` line per
+      entry, with the `op://` reference resolved to the live secret.
+
+      Rendering happens once per graphical session and prompts 1Password to
+      unlock if it is locked. Declaring nothing here leaves the whole mechanism
+      inert, with no prompt and no calls to `op`.
+    '';
+  };
+
+  config = {
+    # Also available by hand, to re-render after changing a value in the vault.
+    home.packages = [ opSecrets ];
+
+    systemd.user.services.op-secrets = {
+      Unit = {
+        Description = "Render 1Password-backed secrets into the session runtime directory";
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+      Service = {
+        Type = "oneshot";
+        # Consumers pull this in via Wants=; without this they would re-trigger
+        # a render, and a fresh unlock prompt, on every activation.
+        RemainAfterExit = true;
+        ExecStart = lib.getExe opSecrets;
+      };
+      Install.WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}

--- a/home/rofi.nix
+++ b/home/rofi.nix
@@ -5,9 +5,14 @@
 
     programs.rofi = {
         enable = true;
+        # Wayland-native build: renders a fullscreen layer-shell surface, so a
+        # tap/click anywhere outside the box dismisses it (X11 rofi's pointer
+        # grab can't see clicks on native Wayland windows under Hyprland).
+        package = pkgs.rofi-wayland;
         terminal = "${pkgs.alacritty}/bin/alacritty";
         extraConfig = {
             modi = "drun";
+            click-to-exit = true;   # tap outside the window to close
             show-icons = true;
             drun-display-format = "{icon} {name}";
             sidebar-mode = false;

--- a/onepassword.nix
+++ b/onepassword.nix
@@ -17,16 +17,17 @@
 
   # 1Password refuses to talk to a browser it cannot recognise, and it matches
   # on executable name against a built-in list that the Nix-built browsers miss.
-  # Both the wrapper and the wrapped binary are listed because the extension
-  # handshake sees the latter.
+  # Chrome's real image is `chrome`, reached through a `google-chrome-stable`
+  # shell wrapper that re-execs it; both names are listed so the match holds
+  # whichever one 1Password ends up seeing.
   environment.etc."1password/custom_allowed_browsers" = {
     text = ''
       chromium
-      .chromium-wrapped
+      chromium-browser
+      chrome
       google-chrome-stable
-      .google-chrome-wrapped
     '';
     # 1Password rejects the file outright if it is group- or world-writable.
-    mode = "0755";
+    mode = "0644";
   };
 }

--- a/onepassword.nix
+++ b/onepassword.nix
@@ -1,0 +1,32 @@
+# 1Password desktop app and `op` CLI.
+#
+# Both NixOS modules exist mainly to install setgid wrappers: the desktop app
+# only accepts connections from helpers it can attribute to the `onepassword`
+# and `onepassword-cli` groups, so calling the bare store binaries instead of
+# the wrappers breaks browser and CLI integration. `polkitPolicyOwners` is what
+# lets the listed users unlock with system authentication rather than retyping
+# the account password.
+{ ... }:
+{
+  programs._1password.enable = true;
+
+  programs._1password-gui = {
+    enable = true;
+    polkitPolicyOwners = [ "leevisuo" ];
+  };
+
+  # 1Password refuses to talk to a browser it cannot recognise, and it matches
+  # on executable name against a built-in list that the Nix-built browsers miss.
+  # Both the wrapper and the wrapped binary are listed because the extension
+  # handshake sees the latter.
+  environment.etc."1password/custom_allowed_browsers" = {
+    text = ''
+      chromium
+      .chromium-wrapped
+      google-chrome-stable
+      .google-chrome-wrapped
+    '';
+    # 1Password rejects the file outright if it is group- or world-writable.
+    mode = "0755";
+  };
+}


### PR DESCRIPTION
Sets up 1Password on both hosts, wires git commit signing to it, and adds a small
mechanism for pulling secrets out of the vault instead of hand-maintaining them.

## What this does

**Desktop app and CLI** (`onepassword.nix`, imported by `configuration.nix`)

`programs._1password` and `programs._1password-gui`. Both modules exist mainly to
install setgid wrappers — the desktop app only accepts connections from helpers it
can attribute to the `onepassword` / `onepassword-cli` groups, so calling the bare
store binaries breaks browser and CLI integration. `polkitPolicyOwners = [ "leevisuo" ]`
makes unlocking use system authentication instead of retyping the account password.

Nix-built browsers aren't on 1Password's built-in list of recognised executables, so
Chromium and Chrome are declared in `/etc/1password/custom_allowed_browsers`. The app
autostarts hidden and locked via a Hyprland `exec-once`, because both the CLI and the
browser extension need it already running.

**Git commit signing** (`home/git.nix`)

SSH signatures via `op-ssh-sign`, so the private half never touches the filesystem.

Worth flagging: `programs.git` had never been enabled, so the module wrote nothing and
the signing settings would have been silently inert. Enabling it is what makes this
work, and it is additive rather than destructive — home-manager emits
`~/.config/git/config`, which git reads *alongside* the existing hand-written
`~/.gitconfig` and loses to it on any key both set. The existing `user.email`,
`push.autoSetupRemote`, `includeIf` for `~/work/` and the `gh` credential helpers are
untouched.

Signing stays **off** until `signingKey` at the top of the file is filled in, since git
rejects every commit when a signing format is set with an empty key.

**Secrets from the vault** (`home/onepassword-secrets.nix`)

Declared `op://` references are rendered at login into
`$XDG_RUNTIME_DIR/op-secrets/<name>.env` — tmpfs-backed and session-private, so no
secret material reaches disk or the Nix store. Only the reference templates live in the
store, and those contain no values. An `op-secrets` command is also on `PATH` to
re-render after changing something in the vault.

Nothing is declared yet, which leaves the mechanism completely inert: no unlock prompt
and no calls to `op` until a reference is added.

The Linear poller is the first consumer. It now treats both its old hand-written
`~/.config/linear/credentials` and the rendered file as optional, with the rendered one
winning, so it keeps working unchanged either way.

## Verification

- `nixosConfigurations.laptop` and `nixosConfigurations.workstation` both build.
- Generated `~/.config/git/config` inspected in both states: with `signingKey = null` it
  emits `commit.gpgSign = false` and no `user.signingKey`; with a key set it flips to
  `gpgSign = true` and emits the key.
- Committed in a scratch repo using the generated config as `GIT_CONFIG_GLOBAL` —
  commit succeeds, signature status `N`, aliases resolve. Confirms the shipped state
  cannot break commits.
- Generated systemd units checked: `op-secrets.service` is `oneshot` +
  `RemainAfterExit`, pulled into `graphical-session.target.wants`; `linear-notify.service`
  has both `EnvironmentFile` lines prefixed `-` and orders after `op-secrets.service`.
- Rendered `op-secrets` script confirmed to be a no-op (just `mkdir`/`chmod`) with
  nothing declared.
- `op` wrapper confirmed setgid `onepassword-cli`.

Not built or booted on real hardware — needs `nixos-rebuild switch` to take effect.

## To finish setup after merging

1. `nixos-rebuild switch`, sign in to the desktop app.
2. Turn on **Settings → Developer → Use the SSH agent** — `op-ssh-sign` reaches the key
   through the agent.
3. Paste the signing key's public half into `signingKey` in `home/git.nix`, and add it to
   GitHub as a **Signing key**.
4. Optionally move the Linear API key into the vault and declare it:
   `services.onepassword-secrets.envFiles.linear.LINEAR_API_KEY = "op://<vault>/<item>/<field>";`

Note this leaves SSH *authentication* alone, as agreed — `git push` keeps using the
on-disk key. Only signing goes through 1Password.