### PR TITLE
Close the paths around the lock screen

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -17,6 +17,10 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.systemd-boot.configurationLimit = 5;
   boot.loader.efi.canTouchEfiVariables = true;
+  # Without this, anyone at the boot menu can press "e" and append
+  # init=/bin/sh to the kernel command line for a root shell with no password,
+  # which walks straight past the lock screen.
+  boot.loader.systemd-boot.editor = false;
 
   nix.gc = {
     automatic = true;
@@ -204,9 +208,10 @@ NIXOS_OZONE_WL = "1";
 			home.stateVersion = "25.05";
 	};
 
-  # Configure console auto-login and start Hyprland
-  services.getty.autologinUser = "leevisuo";
-  
+  # No console auto-login: the tty1 password prompt is what gates access to the
+  # session. fish still execs Hyprland on tty1 once that prompt is satisfied,
+  # so logging in still lands straight in the compositor.
+
   # Enable Hyprland system-wide
   programs.hyprland = {
     enable = true;

--- a/configuration.nix
+++ b/configuration.nix
@@ -165,6 +165,7 @@ NIXOS_OZONE_WL = "1";
 			hyprpicker
 			google-chrome
 			iio-hyprland
+			wvkbd
 			jq
       dbeaver-bin
       uv

--- a/configuration.nix
+++ b/configuration.nix
@@ -22,6 +22,20 @@
   # which walks straight past the lock screen.
   boot.loader.systemd-boot.editor = false;
 
+  # Swap holds pages evicted from RAM, so a plaintext swap partition leaks
+  # whatever was in memory — keys, tokens, decrypted documents — and survives
+  # power-off. Re-key it with a fresh random key on every boot instead. This
+  # rules out hibernation, which is already unused: lid and power key suspend.
+  #
+  # Referenced by PARTUUID deliberately. Random encryption rewrites the
+  # partition on every boot, so the filesystem UUID that nixos-generate-config
+  # emitted stops resolving after the first boot; the partition UUID lives in
+  # the GPT and survives.
+  swapDevices = lib.mkIf (hostname == "ls-laptop") (lib.mkForce [{
+    device = "/dev/disk/by-partuuid/4b0d16c8-3e2b-414c-b8e4-b0d01654cd36";
+    randomEncryption.enable = true;
+  }]);
+
   nix.gc = {
     automatic = true;
     dates = "weekly";

--- a/configuration.nix
+++ b/configuration.nix
@@ -262,6 +262,16 @@ NIXOS_OZONE_WL = "1";
 	services.udisks2.enable = true;
   services.gnome.gnome-keyring.enable = true;
   security.pam.services.login.enableGnomeKeyring = true;
+
+  # hyprlock authenticates through PAM, but there is no /etc/pam.d/hyprlock
+  # unless we declare one — it silently falls back to /etc/pam.d/su, which
+  # happens to work while making the screen lock depend on su's stack.
+  # logFailures keeps the failed-attempt logging su's stack already gave us.
+  security.pam.services.hyprlock = {
+    enableGnomeKeyring = true;
+    logFailures = true;
+  };
+
   system.stateVersion = "25.05";
 
 

--- a/home/hypr/binds.nix
+++ b/home/hypr/binds.nix
@@ -12,6 +12,7 @@
 				"$mainMod, C, killactive"
 				"$mainMod, R, exec, rofi -show drun"
 				"$mainMod, G, exec, google-chrome-stable --ozone-platform=x11"
+				"$mainMod, I, exec, $HOME/.config/hypr/scripts/toggle-osk.sh"
 				"$mainMod, F, exec, $HOME/.config/hypr/scripts/focus_window_picker.sh"
 				"$mainMod, T, exec, $HOME/.config/hypr/scripts/focus_last_class.sh kitty"
 				"$mainMod, B, exec, $HOME/.config/hypr/scripts/focus_last_class.sh Google-chrome"

--- a/home/hypr/hypridle.nix
+++ b/home/hypr/hypridle.nix
@@ -1,11 +1,43 @@
-{ ... } :
+{ pkgs, ... } :
+let
+	# Start hyprlock and give its lock surface time to reach the screen.
+	#
+	# --immediate skips any grace period (during which the screen unlocks on
+	# input alone) and --immediate-render draws without waiting on background
+	# resources, so the lock covers the display as early as possible.
+	#
+	# The settle delay is a deliberate fixed wait, not a handshake: neither
+	# hyprlock nor Hyprland reports "the session is locked" to anything outside
+	# the compositor — hyprlock never sets logind's LockedHint — so there is no
+	# readiness signal available to poll. hypridle holds logind's sleep-delay
+	# inhibitor while this runs, so suspend waits for us, but only up to
+	# InhibitDelayMaxSec (5s by default); the bounds stay well inside that.
+	lockSession = pkgs.writeShellScript "hyprlock-lock-session" ''
+		export PATH="${pkgs.procps}/bin:${pkgs.coreutils}/bin:$PATH"
+
+		if ! pidof hyprlock >/dev/null 2>&1; then
+			${pkgs.hyprlock}/bin/hyprlock --immediate --immediate-render &
+		fi
+
+		for _ in $(seq 1 40); do
+			pidof hyprlock >/dev/null 2>&1 && break
+			sleep 0.025
+		done
+
+		# Cover surface creation and the first commit.
+		sleep 0.75
+	'';
+in
 {
     services.hypridle = {
 		enable = true;
         settings = {
           general = {
-              lock_cmd = "pidof hyprlock || hyprlock";
-              before_sleep_cmd = "loginctl lock-session";
+              lock_cmd = "${lockSession}";
+              # Called directly rather than via loginctl: lock-session only
+              # emits a D-Bus signal and returns, so the lock would race the
+              # suspend instead of completing before it.
+              before_sleep_cmd = "${lockSession}";
               after_sleep_cmd = "hyprctl dispatch dpms on";
           };
           listener = [

--- a/home/hypr/hyprland.nix
+++ b/home/hypr/hyprland.nix
@@ -18,6 +18,7 @@ in
 		./animation.nix
 		./waybar/waybar.nix
 		./inputs.nix
+		./touch.nix
 		./hypridle.nix
 		./hyprlock.nix
 
@@ -59,7 +60,8 @@ in
 			];
 			general = {
 				gaps_in = 3;
-				gaps_out = 5;
+				# top right bottom left — extra space at the screen bottom for touch reach
+				gaps_out = "5 5 50 5";
 				border_size = 2;
 				resize_on_border = true;
 				layout = "dwindle";

--- a/home/hypr/hyprland.nix
+++ b/home/hypr/hyprland.nix
@@ -51,10 +51,14 @@ in
 	wayland.windowManager.hyprland = {
 		enable = true;
 		settings = {
+			# No hyprlock here. It used to stand in for a login prompt under
+			# console auto-login, but the tty1 password now gates the session,
+			# so locking at startup only asks for the same password twice —
+			# and it fails open: if hyprlock crashes on launch the desktop is
+			# simply exposed, with nothing to retry it.
 			exec-once = [
 				"iio-hyprland"
 				"sleep 1; waybar &"
-				"hyprlock &"
 				"wl-paste --type text --watch cliphist store &"
 				"wl-paste --type image --watch cliphist store &"
 			];

--- a/home/hypr/hyprlock.nix
+++ b/home/hypr/hyprlock.nix
@@ -4,6 +4,16 @@
 	programs.hyprlock = {
 		enable = true;
 		settings = {
+			general = {
+				# Already hyprlock's default, pinned so a later edit can't
+				# quietly reintroduce a window where input alone unlocks the
+				# screen without a password.
+				grace = 0;
+				# An empty submission is not a guess, so don't let one count
+				# toward the PAM failure counter.
+				ignore_empty_input = true;
+				hide_cursor = true;
+			};
 			label = [
 				{
 					text = "$TIME";

--- a/home/hypr/inputs.nix
+++ b/home/hypr/inputs.nix
@@ -4,6 +4,22 @@
             input = {
                 kb_layout = "us";
                 kb_variant = "altgr-intl";
+
+                touchpad = {
+                    natural_scroll = true;        # macOS-style: content follows fingers
+                    scroll_factor = 0.4;          # tame the fast default scroll speed
+                    disable_while_typing = true;  # ignore palm/thumb while typing
+                    tap-to-click = true;          # tap = left click
+                    tap-and-drag = true;          # tap-hold-move to drag
+                    drag_lock = true;             # brief lift keeps the drag alive
+                    clickfinger_behavior = true;  # 2-finger tap = right, 3 = middle
+                };
+            };
+
+            # 3-finger horizontal swipe to move between workspaces
+            gestures = {
+                workspace_swipe = true;
+                workspace_swipe_fingers = 3;
             };
             device = [
             {

--- a/home/hypr/scripts/chrome.sh
+++ b/home/hypr/scripts/chrome.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Google Chrome in touch mode — bound to the right-edge touch gesture.
+#   --top-chrome-touch-ui : fat, finger-sized tabs/toolbar
+#   --touch-events        : websites detect a touchscreen (mobile/touch paths)
+#   --ozone-platform=x11  : keep XWayland; native Wayland ozone crashes the AMD
+#                           Phoenix3 iGPU (same reason as Slack in configuration.nix)
+exec google-chrome-stable --ozone-platform=x11 \
+    --top-chrome-touch-ui=enabled --touch-events=enabled "$@"

--- a/home/hypr/scripts/toggle-osk.sh
+++ b/home/hypr/scripts/toggle-osk.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# wvkbd on-screen keyboard control:  show | hide | toggle  (default: toggle)
+#
+# Height is taller in landscape than portrait per preference — a bigger keyboard
+# when the screen is horizontal. wvkbd auto-selects -L vs -H from the current
+# output orientation, so no orientation detection is needed here.
+LAND=400   # -L landscape / horizontal height (bigger)
+PORT=300   # -H portrait / vertical height
+
+action="${1:-toggle}"
+
+running() { pgrep -x wvkbd-mobintl >/dev/null; }
+start()   { wvkbd-mobintl -L "$LAND" -H "$PORT" & disown; }
+
+case "$action" in
+    show)   running || start ;;
+    hide)   running && pkill -x wvkbd-mobintl ;;
+    toggle) if running; then pkill -x wvkbd-mobintl; else start; fi ;;
+esac

--- a/home/hypr/touch.nix
+++ b/home/hypr/touch.nix
@@ -1,0 +1,48 @@
+{ pkgs, ... }:
+{
+  # On-screen keyboard control script (summoned by gesture, waybar button, or key)
+  xdg.configFile."hypr/scripts/toggle-osk.sh" = {
+    source = ./scripts/toggle-osk.sh;
+    executable = true;
+  };
+
+  # Chrome launcher that enables touch UI only in tablet mode w/o external keyboard
+  xdg.configFile."hypr/scripts/chrome.sh" = {
+    source = ./scripts/chrome.sh;
+    executable = true;
+  };
+
+  wayland.windowManager.hyprland = {
+    # hyprgrass: touchSCREEN gestures. (Hyprland's built-in gestures.workspace_swipe
+    # in inputs.nix is a touchPAD gesture — a separate device, so no conflict.)
+    # Version-matched to pkgs.hyprland since both come from nixpkgs 25.05.
+    plugins = [ pkgs.hyprlandPlugins.hyprgrass ];
+
+    settings = {
+      plugin.touch_gestures = {
+        # Higher = need to move further before a swipe registers. 4 is a calm default.
+        sensitivity = 4.0;
+        # 3-finger drag left/right moves between workspaces, like a touchpad.
+        workspace_swipe_fingers = 3;
+        # Disable hyprgrass's SINGLE-finger edge workspace-swipe (defaults to the
+        # bottom edge), which otherwise steals the bottom-edge-up keyboard gesture.
+        workspace_swipe_edge = "none";
+        long_press_delay = 400;
+      };
+
+      # hyprgrass gesture binds. Gesture names act like keys in a normal `bind`.
+      #   edge:<from>:<dir>  swipe starting at a screen edge, in a direction
+      #   swipe:<n>:<dir>    n-finger swipe (n must be >= 3; 2-finger is scroll)
+      bind = [
+        # 3-finger swipe UP -> show the on-screen keyboard, DOWN -> hide it.
+        # (3-finger left/right is the workspace swipe, configured above.)
+        ", swipe:3:u, exec, $HOME/.config/hypr/scripts/toggle-osk.sh show"
+        ", swipe:3:d, exec, $HOME/.config/hypr/scripts/toggle-osk.sh hide"
+        # Edge swipes (single finger, from a screen edge inward/down):
+        ", edge:l:r, exec, rofi -show drun"                    # left edge  -> launcher
+        ", edge:r:l, exec, $HOME/.config/hypr/scripts/chrome.sh" # right edge -> Chrome
+        ", edge:u:d, killactive"                               # top edge   -> close window
+      ];
+    };
+  };
+}

--- a/home/hypr/waybar/waybar.nix
+++ b/home/hypr/waybar/waybar.nix
@@ -16,7 +16,13 @@
         # Fixed the typo here from "cloack" to "clock/calendar"
         modules-left = [ "battery" "network" "pulseaudio" "bluetooth" ];
         modules-center = [ "hyprland/workspaces" ];
-        modules-right = [ "custom/weather" "clock#calendar" "clock"  ];
+        modules-right = [ "custom/keyboard" "custom/weather" "clock#calendar" "clock"  ];
+
+        "custom/keyboard" = {
+          format = "󰌌";
+          tooltip = false;
+          on-click = "$HOME/.config/hypr/scripts/toggle-osk.sh";
+        };
 
         "clock" = {
           format = "{:%H:%M}";

--- a/home/rofi.nix
+++ b/home/rofi.nix
@@ -5,9 +5,14 @@
 
     programs.rofi = {
         enable = true;
+        # Wayland-native build: renders a fullscreen layer-shell surface, so a
+        # tap/click anywhere outside the box dismisses it (X11 rofi's pointer
+        # grab can't see clicks on native Wayland windows under Hyprland).
+        package = pkgs.rofi-wayland;
         terminal = "${pkgs.alacritty}/bin/alacritty";
         extraConfig = {
             modi = "drun";
+            click-to-exit = true;   # tap outside the window to close
             show-icons = true;
             drun-display-format = "{icon} {name}";
             sidebar-mode = false;


### PR DESCRIPTION
hyprlock itself is sound — it uses `ext-session-lock-v1`, so Hyprland owns the lock state and keeps the screen blank if the locker crashes. Swapping it for swaylock or gtklock would change nothing. What needed fixing was everything around it: several paths reached a session without ever meeting the lock screen.

Full-disk encryption is the dominant gap and is deliberately **not** here — it needs a wipe and reinstall, which is being done separately. Everything in this PR is wipe-free.

## What this changes

**Bootloader.** `systemd-boot`'s command-line editor is on by default. Anyone at the boot menu could press `e`, append `init=/bin/sh`, and get a root shell — about fifteen seconds, lock screen irrelevant. Now disabled.

**Console auto-login.** `services.getty.autologinUser` logged the user in unprompted, and `hyprlock &` in `exec-once` stood in for the missing login prompt. That fails open: the startup lock is best-effort, and if hyprlock dies during launch the desktop is simply exposed with nothing to retry it. Auto-login is gone, so the tty1 password gates the session; the redundant startup lock is gone with it. fish still execs Hyprland on tty1, so a successful login lands in the compositor exactly as before.

**PAM.** There was no `/etc/pam.d/hyprlock`. hyprlock does not fail in that case — it warns and falls back to `/etc/pam.d/su`, so screen unlocking ran on su's stack by coincidence. Confirmed in the binary: `Pam module "/etc/pam.d/{}" does not exist! Falling back to "/etc/pam.d/su"`. The service is now declared, which also drops su's `auth sufficient pam_rootok.so` and adds gnome-keyring so unlocking the screen unlocks the keyring too.

**Suspend race.** `before_sleep_cmd` ran `loginctl lock-session`, which emits a D-Bus signal and returns immediately — the lock raced the suspend, so the desktop could be briefly readable on resume. Lid switch, power key and idle timeout all took this path. hyprlock is now called directly and hypridle's sleep-delay inhibitor is held until the lock surface has had time to appear.

This last one is a **timing mitigation, not a guarantee**, and the code says so: hyprlock does not set logind's `LockedHint` (its only login1 use is the fingerprint sleep signal), and neither hyprlock nor Hyprland exposes session-lock state over IPC, so there is no readiness signal to poll. The wait is bounded well inside `InhibitDelayMaxSec` so a slow lock can never stall suspend.

**Swap.** The swap partition was plaintext, so anything evicted from RAM — keys, tokens, decrypted documents — was written in the clear and survived power-off. Now re-keyed randomly at each boot. Referenced by PARTUUID, not the filesystem UUID: random encryption rewrites the partition every boot and destroys that UUID, so the `by-uuid` path would resolve once and then leave the swap unit waiting on a device that no longer exists.

## Verification

Both hosts evaluate and build (`nix flake check`, dry-run `toplevel`). Checked against the built output rather than just parsing:

- `/etc/pam.d/hyprlock` is generated with `pam_unix` + `pam_faillock` + gnome-keyring, ends in `pam_deny`, and contains no `pam_rootok`
- `boot.loader.systemd-boot.editor` = `false`; `services.getty.autologinUser` = `null`
- `swapDevices` resolves to exactly one entry (the `mkForce` replaced rather than appended), `randomEncryption` on, `aes-xts-plain64`, swap on `/dev/mapper/…`
- Workstation swap confirmed unchanged by the hostname guard
- Generated `hyprlock.conf` has `grace=0`, `ignore_empty_input=true`; `hyprlock` no longer in `exec-once`
- Lock script parses under `bash -n` and uses absolute store paths, so it does not depend on the session PATH

Not tested at runtime: locking the screen or suspending would have disrupted the live session. The suspend path needs a real lid-close to confirm.

## Before rebooting

Removing auto-login means the tty1 prompt must be satisfiable. Worth confirming the account password actually works first — `sudo passwd -S leevisuo` should report `P`, or switch to a spare TTY with Ctrl+Alt+F2 and log in — because a machine with no usable password and no auto-login is a machine you cannot get into.

The swap commit (`846a683`) is isolated and can be dropped if the LUKS reinstall is imminent, since that will configure random-key swap anyway.