### PR TITLE
Super+S opens a rofi switcher for Slack conversations

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -17,6 +17,7 @@
     ./home/linear-notify.nix
     ./home/onepassword-secrets.nix
     ./home/claude-notify.nix
+    ./home/slack-switcher.nix
   ];
   # Home Manager needs a bit of information about you and the paths it should
   # manage.
@@ -101,6 +102,9 @@
       "x-scheme-handler/http" = "chromium-browser.desktop";
       "x-scheme-handler/https" = "chromium-browser.desktop";
       "x-scheme-handler/ftp" = "chromium-browser.desktop";
+      # This list is managed explicitly, so name the Slack handler rather than
+      # relying on a fallback to the system-wide association.
+      "x-scheme-handler/slack" = "slack.desktop";
       "text/html" = "chromium-browser.desktop";
       "application/xhtml+xml" = "chromium-browser.desktop";
       "application/json" = "kitty-nvim.desktop";

--- a/home/hypr/binds.nix
+++ b/home/hypr/binds.nix
@@ -20,6 +20,7 @@
 				"$mainMod, W, exec, killall -SIGUSR1 waybar"
 				"$mainMod, L, exec, hyprlock"
 				"$mainMod, O, exec, planify"
+				"$mainMod, S, exec, slack-switcher"
 # Dwiddle and toggle split
 				"$mainMod, J, togglesplit, # dwindle"
 				"$mainMod, K, swapsplit"

--- a/home/slack-switcher.nix
+++ b/home/slack-switcher.nix
@@ -24,9 +24,32 @@ let
     # kicks off a refresh in the background but still shows the stale list.
     STALE_AFTER = 3600
 
+    # Past this the cache is not merely due a refresh, something is wrong with
+    # it — say so in the prompt rather than quietly serving month-old names.
+    SUSPECT_AFTER = STALE_AFTER * 24
+
+    # Enough history to order the list, few enough that the file stays small.
+    MRU_LIMIT = 200
+
     # Resolved by the icon theme rather than being a path, so every channel row
     # carries the Slack mark while people rows carry a real face.
     CHANNEL_ICON = "slack"
+
+
+    class NoRedirect(urllib.request.HTTPRedirectHandler):
+        """Refuse redirects on authenticated calls.
+
+        urllib copies the request headers onto the redirect target, including
+        across hosts, which would hand the token to whatever the redirect names.
+        Slack's API does not redirect, so refusing outright costs nothing.
+        """
+
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            raise urllib.error.HTTPError(
+                req.full_url, code, "unexpected redirect to " + newurl, headers, fp)
+
+
+    OPENER = urllib.request.build_opener(NoRedirect)
 
 
     def api(method, **params):
@@ -36,17 +59,28 @@ let
         req = urllib.request.Request(url, headers={"Authorization": "Bearer " + TOKEN})
 
         # A workspace with many channels needs enough pages to reach Slack's
-        # per-method rate limit, and one 429 would otherwise abandon the whole
-        # refresh and leave the cache silently stale.
+        # per-method rate limit, and a laptop refreshing on a timer wakes to a
+        # dead network often enough to matter. Either abandoning the refresh
+        # would leave the cache silently stale for an hour.
         for attempt in range(5):
             try:
-                with urllib.request.urlopen(req, timeout=15) as r:
+                with OPENER.open(req, timeout=15) as r:
                     payload = json.loads(r.read())
                 break
             except urllib.error.HTTPError as e:
                 if e.code != 429 or attempt == 4:
                     raise
-                time.sleep(int(e.headers.get("Retry-After", 5)) + 1)
+                try:
+                    delay = int(e.headers.get("Retry-After", 5))
+                except (TypeError, ValueError):
+                    # Retry-After may also be an HTTP date; the default is close
+                    # enough that parsing one is not worth the code.
+                    delay = 5
+                time.sleep(delay + 1)
+            except OSError:
+                if attempt == 4:
+                    raise
+                time.sleep(2 ** attempt)
 
         if not payload.get("ok"):
             raise RuntimeError(method + ": " + str(payload.get("error", "unknown error")))
@@ -65,12 +99,36 @@ let
                 return
 
 
+    def write_atomic(path, data):
+        """Write via a temp file and rename.
+
+        The refresh unit is PartOf=graphical-session.target, so logging out can
+        SIGTERM it mid-write; a half-written cache would read as corrupt and
+        take the switcher down with it.
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(path.name + "." + str(os.getpid()) + ".tmp")
+        if isinstance(data, str):
+            tmp.write_text(data)
+        else:
+            tmp.write_bytes(data)
+        os.replace(tmp, path)
+
+
+    def read_json(path, fallback):
+        try:
+            return json.loads(path.read_text())
+        except Exception:
+            return fallback
+
+
     def avatar(url):
         """Cache an avatar under a URL-derived name and return its path.
 
         Slack rewrites the URL whenever someone changes their picture, so keying
         on the URL means a new picture lands as a new file instead of being
-        masked by a stale cache entry.
+        masked by a stale cache entry. The flip side is that a truncated file
+        would never be retried, hence the atomic write.
         """
         if not url:
             return None
@@ -82,19 +140,20 @@ let
                 data = r.read()
         except Exception:
             return None
-        dest.write_bytes(data)
+        write_atomic(dest, data)
         return dest
 
 
-    def refresh():
-        if not TOKEN:
-            print("slack-switcher: no SLACK_TOKEN, nothing to refresh", file=sys.stderr)
-            return 0
-
+    def collect():
+        """Build the conversation list. Returns (team_id, entries, complete)."""
         AVATARS.mkdir(parents=True, exist_ok=True)
         team_id = api("auth.test")["team_id"]
         entries = []
+        faces = set()
+        complete = True
 
+        # Every public channel, not only the joined ones: the point of a
+        # switcher is to reach a channel you are not already sitting in.
         for c in paged("conversations.list", "channels",
                        types="public_channel", exclude_archived="true"):
             entries.append({
@@ -104,24 +163,28 @@ let
                 "kind": "channel",
             })
 
-        # users.info per DM partner rather than one users.list: the number of
-        # open DMs is small, while the workspace directory is not, and there is
-        # no reason to pull down people you never message.
-        keep = set()
         for im in paged("users.conversations", "channels", types="im"):
             uid = im.get("user")
             if not uid:
                 continue
+            # users.info per DM partner rather than one users.list: the people
+            # you message are a small set, the workspace directory is not.
             try:
                 profile = api("users.info", user=uid)["user"]
             except Exception:
+                # Keep the conversation under a placeholder rather than dropping
+                # it. An omitted entry is indistinguishable from a DM that no
+                # longer exists, and would be cached as such for an hour.
+                complete = False
+                entries.append({"id": im["id"], "user": uid, "label": "@" + uid,
+                                "icon": CHANNEL_ICON, "kind": "im"})
                 continue
             name = (profile.get("profile", {}).get("display_name")
                     or profile.get("real_name")
                     or profile.get("name", uid))
             face = avatar(profile.get("profile", {}).get("image_48"))
             if face:
-                keep.add(face.name)
+                faces.add(face.name)
             entries.append({
                 "id": im["id"],
                 "user": uid,
@@ -130,29 +193,49 @@ let
                 "kind": "im",
             })
 
-        for stale in AVATARS.iterdir():
-            if stale.name not in keep:
-                stale.unlink(missing_ok=True)
+        return team_id, entries, complete, faces
 
-        DATA.mkdir(parents=True, exist_ok=True)
-        CACHE.write_text(json.dumps({
+
+    def refresh():
+        if not TOKEN:
+            print("slack-switcher: no SLACK_TOKEN, nothing to refresh", file=sys.stderr)
+            return 0
+        try:
+            team_id, entries, complete, faces = collect()
+        except Exception as e:
+            # Leave the old cache in place: a stale list beats no list, and the
+            # unit failing is what makes the problem visible in the journal.
+            print("slack-switcher: refresh failed: " + str(e), file=sys.stderr)
+            return 1
+
+        write_atomic(CACHE, json.dumps({
             "team_id": team_id,
             "fetched_at": int(time.time()),
             "entries": entries,
         }))
+
+        # Only after a clean run, and only after the cache naming them is on
+        # disk: a run that failed a lookup has an incomplete picture of which
+        # faces are still in use, and would delete the rest.
+        if complete:
+            for stale in AVATARS.iterdir():
+                if stale.name not in faces:
+                    stale.unlink(missing_ok=True)
+
         print("slack-switcher: cached " + str(len(entries)) + " conversations")
         return 0
 
 
-    def read_json(path, fallback):
-        try:
-            return json.loads(path.read_text())
-        except Exception:
-            return fallback
-
-
     def notify(body):
         subprocess.run(["${pkgs.libnotify}/bin/notify-send", "-a", "Slack", "Slack switcher", body])
+
+
+    def request_refresh():
+        subprocess.Popen(
+            ["${pkgs.systemd}/bin/systemctl", "--user", "start", "--no-block",
+             "slack-switcher-refresh.service"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
 
 
     def order(entries, mru):
@@ -172,16 +255,16 @@ let
 
     def launch():
         cache = read_json(CACHE, None)
-        if not cache or not cache.get("entries"):
-            notify("No cached conversations yet. Run: slack-switcher --refresh")
+        if not cache or not cache.get("entries") or not cache.get("team_id"):
+            # Covers first run and a cache that failed to parse. Kick off the
+            # rebuild here so recovering never means opening a terminal.
+            request_refresh()
+            notify("Building the conversation list — try again in a moment.")
             return 1
 
-        if time.time() - cache.get("fetched_at", 0) > STALE_AFTER:
-            subprocess.Popen(
-                ["${pkgs.systemd}/bin/systemctl", "--user", "start", "--no-block",
-                 "slack-switcher-refresh.service"],
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            )
+        age = time.time() - cache.get("fetched_at", 0)
+        if age > STALE_AFTER:
+            request_refresh()
 
         mru = read_json(MRU, {})
         entries = order(cache["entries"], mru)
@@ -191,7 +274,10 @@ let
 
         picked = subprocess.run(
             ["${config.programs.rofi.package}/bin/rofi",
-             "-dmenu", "-i", "-p", "Slack",
+             "-dmenu", "-i",
+             # Refreshes have been failing long enough that the names on screen
+             # can no longer be trusted; say so where it will be read.
+             "-p", "Slack (stale)" if age > SUSPECT_AFTER else "Slack",
              # Index rather than text: labels are user-controlled and need not
              # round-trip back to an id.
              "-format", "i",
@@ -211,9 +297,10 @@ let
             return 1
 
         mru[entry["id"]] = int(time.time())
-        live = set(e["id"] for e in cache["entries"])
-        MRU.parent.mkdir(parents=True, exist_ok=True)
-        MRU.write_text(json.dumps({k: v for k, v in mru.items() if k in live}))
+        # Trimmed by age, not filtered against the cache: a refresh that missed
+        # a conversation must not erase the history that orders the whole list.
+        newest = sorted(mru.items(), key=lambda kv: -kv[1])[:MRU_LIMIT]
+        write_atomic(MRU, json.dumps(dict(newest)))
 
         url = "slack://channel?" + urllib.parse.urlencode({
             "team": cache["team_id"], "id": entry["id"],
@@ -223,9 +310,13 @@ let
         # start a second, differently-flagged instance.
         subprocess.run(["${pkgs.xdg-utils}/bin/xdg-open", url])
         # The deep link does not reliably raise the window under Hyprland.
-        # hyprctl comes from PATH so it always matches the running compositor.
-        subprocess.run(["hyprctl", "dispatch", "focuswindow", "class:Slack"],
-                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        # hyprctl comes from PATH so it always matches the running compositor,
+        # which also means it may not be there at all.
+        try:
+            subprocess.run(["hyprctl", "dispatch", "focuswindow", "class:Slack"],
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except OSError:
+            pass
         return 0
 
 

--- a/home/slack-switcher.nix
+++ b/home/slack-switcher.nix
@@ -1,0 +1,275 @@
+# Super+S opens a rofi list of Slack conversations and jumps straight into the
+# selected one.
+#
+# The list is built by a background timer rather than on keypress: the Slack Web
+# API needs several round trips (and one avatar download per person), which is
+# far too slow to sit between a keystroke and a visible menu. The launcher only
+# ever reads the cache, so the menu appears instantly and works offline.
+{ config, pkgs, ... }:
+
+let
+  script = pkgs.writeScriptBin "slack-switcher" ''
+    #!${pkgs.python3}/bin/python3
+    """Cache Slack conversations (--refresh) or pick one and open it (no args)."""
+    import hashlib, json, os, pathlib, subprocess, sys, time
+    import urllib.error, urllib.parse, urllib.request
+
+    TOKEN = os.environ.get("SLACK_TOKEN", "")
+    DATA = pathlib.Path.home() / ".local/share/slack-switcher"
+    CACHE = DATA / "channels.json"
+    MRU = DATA / "mru.json"
+    AVATARS = pathlib.Path.home() / ".cache/slack-switcher/avatars"
+
+    # Matches the refresh timer. Pressing the bind on a cache older than this
+    # kicks off a refresh in the background but still shows the stale list.
+    STALE_AFTER = 3600
+
+    # Resolved by the icon theme rather than being a path, so every channel row
+    # carries the Slack mark while people rows carry a real face.
+    CHANNEL_ICON = "slack"
+
+
+    def api(method, **params):
+        url = "https://slack.com/api/" + method
+        if params:
+            url += "?" + urllib.parse.urlencode(params)
+        req = urllib.request.Request(url, headers={"Authorization": "Bearer " + TOKEN})
+
+        # A workspace with many channels needs enough pages to reach Slack's
+        # per-method rate limit, and one 429 would otherwise abandon the whole
+        # refresh and leave the cache silently stale.
+        for attempt in range(5):
+            try:
+                with urllib.request.urlopen(req, timeout=15) as r:
+                    payload = json.loads(r.read())
+                break
+            except urllib.error.HTTPError as e:
+                if e.code != 429 or attempt == 4:
+                    raise
+                time.sleep(int(e.headers.get("Retry-After", 5)) + 1)
+
+        if not payload.get("ok"):
+            raise RuntimeError(method + ": " + str(payload.get("error", "unknown error")))
+        return payload
+
+
+    def paged(method, key, **params):
+        cursor = ""
+        while True:
+            page = api(method, cursor=cursor, limit=200, **params) if cursor \
+                else api(method, limit=200, **params)
+            for item in page.get(key, []):
+                yield item
+            cursor = (page.get("response_metadata") or {}).get("next_cursor", "")
+            if not cursor:
+                return
+
+
+    def avatar(url):
+        """Cache an avatar under a URL-derived name and return its path.
+
+        Slack rewrites the URL whenever someone changes their picture, so keying
+        on the URL means a new picture lands as a new file instead of being
+        masked by a stale cache entry.
+        """
+        if not url:
+            return None
+        dest = AVATARS / (hashlib.sha256(url.encode()).hexdigest()[:16] + ".jpg")
+        if dest.exists():
+            return dest
+        try:
+            with urllib.request.urlopen(url, timeout=10) as r:
+                data = r.read()
+        except Exception:
+            return None
+        dest.write_bytes(data)
+        return dest
+
+
+    def refresh():
+        if not TOKEN:
+            print("slack-switcher: no SLACK_TOKEN, nothing to refresh", file=sys.stderr)
+            return 0
+
+        AVATARS.mkdir(parents=True, exist_ok=True)
+        team_id = api("auth.test")["team_id"]
+        entries = []
+
+        for c in paged("conversations.list", "channels",
+                       types="public_channel", exclude_archived="true"):
+            entries.append({
+                "id": c["id"],
+                "label": "#" + c["name"],
+                "icon": CHANNEL_ICON,
+                "kind": "channel",
+            })
+
+        # users.info per DM partner rather than one users.list: the number of
+        # open DMs is small, while the workspace directory is not, and there is
+        # no reason to pull down people you never message.
+        keep = set()
+        for im in paged("users.conversations", "channels", types="im"):
+            uid = im.get("user")
+            if not uid:
+                continue
+            try:
+                profile = api("users.info", user=uid)["user"]
+            except Exception:
+                continue
+            name = (profile.get("profile", {}).get("display_name")
+                    or profile.get("real_name")
+                    or profile.get("name", uid))
+            face = avatar(profile.get("profile", {}).get("image_48"))
+            if face:
+                keep.add(face.name)
+            entries.append({
+                "id": im["id"],
+                "user": uid,
+                "label": "@" + name,
+                "icon": str(face) if face else CHANNEL_ICON,
+                "kind": "im",
+            })
+
+        for stale in AVATARS.iterdir():
+            if stale.name not in keep:
+                stale.unlink(missing_ok=True)
+
+        DATA.mkdir(parents=True, exist_ok=True)
+        CACHE.write_text(json.dumps({
+            "team_id": team_id,
+            "fetched_at": int(time.time()),
+            "entries": entries,
+        }))
+        print("slack-switcher: cached " + str(len(entries)) + " conversations")
+        return 0
+
+
+    def read_json(path, fallback):
+        try:
+            return json.loads(path.read_text())
+        except Exception:
+            return fallback
+
+
+    def notify(body):
+        subprocess.run(["${pkgs.libnotify}/bin/notify-send", "-a", "Slack", "Slack switcher", body])
+
+
+    def order(entries, mru):
+        """Anything you have opened before, most recent first; then the rest.
+
+        Slack's API exposes no last-message timestamp on any list call, so this
+        ranks by your own jump history instead — which is the recency that
+        actually matters once the list has been used for a few days.
+        """
+        def key(e):
+            last = mru.get(e["id"])
+            if last is not None:
+                return (0, -last, "")
+            return (1 if e["kind"] == "im" else 2, 0, e["label"].lower())
+        return sorted(entries, key=key)
+
+
+    def launch():
+        cache = read_json(CACHE, None)
+        if not cache or not cache.get("entries"):
+            notify("No cached conversations yet. Run: slack-switcher --refresh")
+            return 1
+
+        if time.time() - cache.get("fetched_at", 0) > STALE_AFTER:
+            subprocess.Popen(
+                ["${pkgs.systemd}/bin/systemctl", "--user", "start", "--no-block",
+                 "slack-switcher-refresh.service"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+
+        mru = read_json(MRU, {})
+        entries = order(cache["entries"], mru)
+
+        # rofi's dmenu icon protocol: "<text>\0icon\x1f<name-or-path>" per row.
+        rows = "\n".join(e["label"] + "\0icon\x1f" + e["icon"] for e in entries)
+
+        picked = subprocess.run(
+            ["${config.programs.rofi.package}/bin/rofi",
+             "-dmenu", "-i", "-p", "Slack",
+             # Index rather than text: labels are user-controlled and need not
+             # round-trip back to an id.
+             "-format", "i",
+             "-no-custom",
+             # Keep the recency order intact while filtering, instead of letting
+             # rofi re-rank matches by fuzzy score.
+             "-no-sort",
+             "-show-icons",
+             "-theme-str", 'entry { placeholder: "Search Slack..."; }'],
+            input=rows, capture_output=True, text=True,
+        )
+        if picked.returncode != 0 or not picked.stdout.strip():
+            return 0
+        try:
+            entry = entries[int(picked.stdout.strip())]
+        except (ValueError, IndexError):
+            return 1
+
+        mru[entry["id"]] = int(time.time())
+        live = set(e["id"] for e in cache["entries"])
+        MRU.parent.mkdir(parents=True, exist_ok=True)
+        MRU.write_text(json.dumps({k: v for k, v in mru.items() if k in live}))
+
+        url = "slack://channel?" + urllib.parse.urlencode({
+            "team": cache["team_id"], "id": entry["id"],
+        })
+        # Through xdg-open, not a store path: the Slack on PATH is wrapped with
+        # --ozone-platform=x11 for the iGPU, and an unwrapped pkgs.slack would
+        # start a second, differently-flagged instance.
+        subprocess.run(["${pkgs.xdg-utils}/bin/xdg-open", url])
+        # The deep link does not reliably raise the window under Hyprland.
+        # hyprctl comes from PATH so it always matches the running compositor.
+        subprocess.run(["hyprctl", "dispatch", "focuswindow", "class:Slack"],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return 0
+
+
+    if __name__ == "__main__":
+        if "--refresh" in sys.argv[1:]:
+            sys.exit(refresh())
+        sys.exit(launch())
+  '';
+in
+{
+  home.packages = [ script ];
+
+  services.onepassword-secrets.envFiles.slack.SLACK_TOKEN =
+    "op://Private/Slack switcher/credential";
+
+  systemd.user.services.slack-switcher-refresh = {
+    Unit = {
+      Description = "Cache Slack conversations for the rofi switcher";
+      # Ordered after the secret render but deliberately not pulling it in, for
+      # the same reason as linear-notify: this runs from a timer, and a Wants=
+      # would re-activate a failed render on every tick.
+      After = [ "graphical-session.target" "op-secrets.service" ];
+      PartOf = [ "graphical-session.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${script}/bin/slack-switcher --refresh";
+      # Both optional, later wins: the token normally comes from 1Password, but
+      # a hand-written ~/.config/slack/credentials holding SLACK_TOKEN=xoxp-xxx
+      # still works. With neither, the refresh exits without touching the cache.
+      EnvironmentFile = [
+        "-%h/.config/slack/credentials"
+        "-%t/op-secrets/slack.env"
+      ];
+    };
+  };
+
+  systemd.user.timers.slack-switcher-refresh = {
+    Unit.Description = "Refresh the Slack conversation cache hourly";
+    Timer = {
+      OnStartupSec = "1m";
+      OnUnitActiveSec = "1h";
+      Unit = "slack-switcher-refresh.service";
+    };
+    Install.WantedBy = [ "timers.target" ];
+  };
+}


### PR DESCRIPTION
Jumping to a Slack conversation means focusing the window first and then using the in-app switcher. This adds a `Super+S` bind that opens rofi directly on a list of public channels and open DMs; enter jumps into the selected one.

## How it works

- **`slack-switcher --refresh`** — a systemd user oneshot on an hourly timer. Pulls public channels (`conversations.list`), open DMs (`users.conversations` + `users.info`), and the team id (`auth.test`), then writes `~/.local/share/slack-switcher/channels.json` and downloads each DM partner's avatar.
- **`slack-switcher`** — the bind. Reads the cache, shows rofi, opens `slack://channel?team=…&id=…` via `xdg-open`. It never makes a network call, so the menu appears instantly and works offline. A cache older than the timer interval starts a refresh in the background and shows the stale list meanwhile, so a new channel appears on the next press instead of stalling the current one.

## Notable decisions

**Ordering is your own jump history.** Slack's Web API exposes no last-message timestamp on any list call — getting true activity order would need one `conversations.history` request per channel. So the list ranks by the conversations you have actually jumped to, most recent first, then DMs, then channels alphabetically. rofi gets `-no-sort` so that order survives filtering rather than being re-ranked by fuzzy match score.

**Icons.** People rows carry the person's real avatar, channel rows the Slack mark, via rofi's dmenu icon protocol. Avatars are cached under a name derived from their URL, so a changed picture lands as a new file instead of being masked by a stale entry.

**`xdg-open`, not a store path.** The `slack` on PATH is wrapped in `configuration.nix` with `--ozone-platform=x11` for the AMD iGPU. Referencing `pkgs.slack` from home-manager would start a second, differently-flagged instance.

**Degraded refreshes cannot corrupt the list.** A DM whose `users.info` fails is kept under a placeholder rather than dropped, since an omitted entry is indistinguishable from a conversation that no longer exists. Avatar pruning waits for a run that resolved everything. The jump history is trimmed by age rather than filtered against the cache, so a partial refresh cannot erase the data the whole ordering depends on. A refresh that fails outright leaves the previous cache alone and exits non-zero so the journal shows why. All three files are written through a temp file and a rename, because the unit is `PartOf=graphical-session.target` and logging out can kill it mid-write.

## Before this works — one manual step

Create the token, or `op-secrets` will fail at every login (it currently has nothing to render, so this is the first entry to activate it):

1. api.slack.com/apps → **Create New App** → **OAuth & Permissions** → **User Token Scopes**: `channels:read`, `im:read`, `users:read` → **Install to Workspace**. A *user* token (`xoxp-`) is required so the DM list is yours; a bot token would not see it. Your workspace may require admin approval for the install.
2. Store it in 1Password as `Private / Slack switcher / credential`.

A hand-written `~/.config/slack/credentials` holding `SLACK_TOKEN=xoxp-…` also works and takes lower precedence, matching how the Linear poller gets its key. With no token at all the refresh exits quietly and the bind reports that the list is still being built.

## Verification

Both halves of the script were driven against stubbed `rofi`/`xdg-open`/`hyprctl` and a stubbed Slack HTTP layer — 56 assertions covering ordering, the icon protocol, MRU persistence and capping, deep-link construction, cache corruption and recovery, pagination, the 429 retry (including a `Retry-After` in HTTP-date form), degraded and hard-failed refreshes, avatar caching and pruning, and redirect refusal on token-bearing requests. The full NixOS config evaluates and the script derivation builds.

Not yet exercised against a live workspace — that needs the token above. Worth confirming on first use that the DM deep link lands in the conversation (channels are the well-trodden path; each DM entry also carries its `user` id, so switching to `slack://user?…` is a one-line change if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)